### PR TITLE
chore(ci): migrate Linux jobs to self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   backend-tests:
     name: Backend Tests (Jest)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
@@ -39,7 +39,7 @@ jobs:
 
   frontend-tests:
     name: Frontend Tests (Vitest)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
@@ -59,7 +59,7 @@ jobs:
 
   claim-drafter-tests:
     name: Claim Drafter Tests (pytest)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
@@ -74,7 +74,7 @@ jobs:
 
   compliance-checker-tests:
     name: Compliance Checker Tests (pytest)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
@@ -89,7 +89,7 @@ jobs:
 
   application-generator-tests:
     name: Application Generator Tests (pytest)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
@@ -104,7 +104,7 @@ jobs:
 
   build:
     name: Build Check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     needs: [backend-tests, frontend-tests, claim-drafter-tests, compliance-checker-tests, application-generator-tests]
     steps:
       - uses: actions/checkout@v5
@@ -135,7 +135,7 @@ jobs:
 
   e2e-tests:
     name: Browser E2E Tests (Playwright)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     needs: [build]
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,7 +171,7 @@ jobs:
           path: build/PatentForgeLocal-*.dmg
 
   build-linux:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - uses: actions/checkout@v4
 
@@ -239,7 +239,7 @@ jobs:
 
   create-release:
     needs: [build-windows, build-mac, build-linux]
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Migrates Linux jobs to runs-on: [self-hosted, linux, x64], targeting the new self-hosted runner registered to this repo (`nvideablackwell-patentforgelocal-2404`). Windows-latest / macos-latest jobs preserved (no self-hosted runner for those OSes).

Runner host: WSL Ubuntu 24.04 LTS on new-box (NvideaBlackwell, RTX 5070).

Pattern follows [CivicSuite/civicsuite#133](https://github.com/CivicSuite/civicsuite/pull/133) (merged a9bb54a, full CI green on self-hosted).