### PR TITLE
pipeline-cw: Verify and complete the v0.4 **Phase 1** contract for `services/claim-

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ htmlcov/
 # Temporary
 tmp/
 *.tmp
+.claude/handoff_current.md
+.pipeline-cw/

--- a/services/claim-drafter/PHASE-1-STATE.md
+++ b/services/claim-drafter/PHASE-1-STATE.md
@@ -1,0 +1,62 @@
+# Phase 1 State — claim-drafter (PatentForgeLocal v0.4)
+
+Status as of 2026-05-14. This document exists so the next operator does not
+re-request a "Phase 1 skeleton scaffold" task on a service that is already past
+Phase 1.
+
+## Phase 1 contract (per v0.4-SCOPE.md L195-201)
+
+The Phase 1 acceptance contract is:
+
+1. FastAPI server on port 3002 with health check
+2. LangGraph state machine with placeholder agents
+3. Pydantic models for request/response
+4. Docker Compose integration
+5. Basic test suite with mocked agents
+
+All five items are satisfied in this fork. Specifically:
+
+| Phase 1 item | Where it lives | Notes |
+|---|---|---|
+| FastAPI server on port 3002 | `src/server.py` | PORT from env (default 3002); Dockerfile binds 3002 |
+| Health check | `src/server.py` — `GET /health` and `GET /healthz` (alias) | `/healthz` added 2026-05-14 to match Kubernetes-style probes; `/health` is the original path used by docker-compose healthcheck |
+| LangGraph state machine | `src/graph.py` | Real implementation, past the "placeholder" Phase 1 bar |
+| Three agent nodes | `src/agents/{planner,writer,examiner}.py` | Real Ollama-backed implementations, past placeholder |
+| Pydantic models | `src/models.py` | `ClaimDraftRequest`, `ClaimDraftResult`, `Claim`, plus `PriorArt`, `DraftSettings`, `GraphState` |
+| prompts/ | `src/prompts/{planner,writer,examiner,common-rules}.md` | CC BY-SA 4.0 prompt files authored |
+| parser.py | `src/parser.py` | Claim-text parser covered by 22 passing tests |
+| Dockerfile | `services/claim-drafter/Dockerfile` | python:3.12-slim, EXPOSE 3002 |
+| docker-compose entry | `docker-compose.yml` → `claim-drafter` | Healthcheck currently hits `/health`; `/healthz` alias also available |
+| Test suite | `tests/` | 87 collected; 82 in non-Ollama scope pass; 4 in `test_auth.py` hang on missing Ollama (see below) |
+
+## Beyond Phase 1
+
+This service already contains substantial Phase 2-4 work inherited from the upstream PatentForge fork and migrated to Ollama in commits `7a90aba` / `c291adb` / `d5bd05b` / `67aba0d` / `e29c3ac` / `836c8ee` / `5749c24`. The server version string is `0.5.0`. The service includes:
+
+- SSE streaming endpoint (`/draft` returns event-stream with keepalive)
+- Synchronous endpoint (`/draft/sync`) for simple integration
+- Internal-service auth via `X-Internal-Secret` header (env-gated; dev mode disables when secret unset)
+- Prompt-hash integrity surface in `/health` body
+- Cost tracking, retry logic with exponential backoff
+- 87-test suite covering models, parser, retry, cost, graph, three agents, SSE streaming, auth
+
+## Known pre-existing issue — test_auth.py hang
+
+Four tests in `tests/test_auth.py` POST to `/draft/sync`, which executes the full LangGraph pipeline against an Ollama URL provided in the request body. When Ollama is not running on the host, the retry path does not short-circuit connection-refused fast enough on Windows, and the tests hang for several minutes per case. Running `pytest -q` from a clean clone without Ollama therefore appears to hang.
+
+**Workaround for CI / local-dev without Ollama:** `pytest -q --ignore=tests/test_auth.py` produces 82 passes in ~1.5s.
+
+**Proper fix (out of scope for this Phase 1 work):**
+- mock the OpenAI/httpx client at module boundary in test_auth.py so it never touches the network, or
+- use `httpx.MockTransport` / `respx` to inject a fast connection-refused response, or
+- set a short connect timeout (e.g. 250ms) in the retry helper specifically when `OLLAMA_HOST` points to localhost during pytest runs.
+
+Filing this here so the Phase 5 (backend adapter) or test-infra-hardening cycle can address it without re-discovering the cause.
+
+## Phase 1 sign-off
+
+- Acceptance criteria from the v0.4 scope: **all five met**.
+- Verification at `2026-05-14T20:55Z`: `pytest -q --ignore=tests/test_auth.py` → 86 passed in 1.88s (82 pre-existing + 4 new in `test_health.py`).
+- No greenfield rewrite was performed; the existing implementation was preserved.
+
+The next live phase to work is **Phase 5** (backend adapter) per `v0.4-SCOPE.md` L223-228. Phase 2, 3, 4 are already implemented in the fork at commit history above.

--- a/services/claim-drafter/src/server.py
+++ b/services/claim-drafter/src/server.py
@@ -84,6 +84,13 @@ async def health():
     }
 
 
+# Alias for callers that expect the Kubernetes-style /healthz path. Same payload
+# as /health so docker-compose healthcheck and any backend probe behave identically.
+@app.get("/healthz")
+async def healthz():
+    return await health()
+
+
 # ── Claim drafting endpoint ──────────────────────────────────────────────────
 
 @app.post("/draft", dependencies=[Depends(verify_internal_secret)])

--- a/services/claim-drafter/tests/test_health.py
+++ b/services/claim-drafter/tests/test_health.py
@@ -1,0 +1,52 @@
+"""
+Health-route tests — `/health` and its `/healthz` alias.
+
+These do not touch the LangGraph pipeline or Ollama; they only verify the
+FastAPI app boots and both health paths return 200 with `status: ok`. Phase 1
+contract: "FastAPI server boots, health endpoint returns 200".
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.server import app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+class TestHealthRoutes:
+    def test_health_returns_200_with_status_ok(self, client):
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "ok"
+        assert body["service"] == "patentforge-claim-drafter"
+        assert "promptHashes" in body
+
+    def test_healthz_alias_returns_200_with_status_ok(self, client):
+        resp = client.get("/healthz")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "ok"
+        assert body["service"] == "patentforge-claim-drafter"
+        assert "promptHashes" in body
+
+    def test_health_and_healthz_return_identical_payloads(self, client):
+        a = client.get("/health").json()
+        b = client.get("/healthz").json()
+        assert a == b
+
+    def test_fastapi_boots_without_env_vars(self):
+        # Re-importing the app object must not blow up even when no
+        # INTERNAL_SERVICE_SECRET or OLLAMA_HOST are set in the environment.
+        from src.server import app as fresh_app
+        assert fresh_app is not None
+        # Routes are registered (smoke check).
+        paths = {r.path for r in fresh_app.routes}
+        assert "/health" in paths
+        assert "/healthz" in paths


### PR DESCRIPTION
## Goal

Verify and complete the v0.4 **Phase 1** contract for `services/claim-drafter/` per `v0.4-SCOPE.md` lines 195–201, filling any spec gaps in the existing scaffold without destroying real work that is already past Phase 1.

## Pre-ship audit

_See `.pipeline-cw/2026-05-14-1422-claim-drafter-skeleton/audit.md` for the full 5-lens findings (Engineering / UX / Tests / Docs / QA)._

## Run trace

Full evidence log: `.pipeline-cw/2026-05-14-1422-claim-drafter-skeleton/log.md` (append-only, UTC-timestamped, every check command + output captured).

---
_Generated by pipeline-cw. Run-id: `2026-05-14-1422-claim-drafter-skeleton`._
