### PR TITLE
Add Provider enum + cloudApiKey to backend AppSettings schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
+### Added (merge plan Run 4 — Prisma provider routing)
+
+- **`AppSettings` schema extended with provider routing fields** in `backend/prisma/schema.prisma`:
+  - `provider` (String, default `"LOCAL"`) — the LLM provider choice. SQLite has no native enum support (Prisma P1012), so the safety lives across three layers: a TypeScript union type (`Provider = "LOCAL" | "CLOUD"` in `backend/src/settings/provider.types.ts`) catches typos at compile time, the DTO's `@IsIn(PROVIDERS)` validator rejects bad values at the HTTP boundary, and the SQLite `CHECK ("provider" IN ('LOCAL', 'CLOUD'))` constraint rejects writes at the runtime DB layer.
+  - `cloudApiKey` (String, default `""`) — Anthropic API key, encrypted at rest using the existing `encryption.ts` pattern (AES-256-GCM with machine-derived key + stored salt).
+  - `cloudDefaultModel` (String, default `"claude-haiku-4-5-20251001"`) — preserves the user's cloud model choice independently of `localDefaultModel`, so switching providers doesn't clobber the unused side.
+  - `localDefaultModel` (String, default `"gemma4:e4b"`) — same idea for Ollama.
+
+- **Idempotent additive migration for existing installs** (`backend/src/prisma/prisma.service.ts:migrateSettings()`):
+  - `ALTER TABLE "AppSettings" ADD COLUMN` for each of the four new columns, each wrapped in try/catch — duplicate-column errors are expected on every boot after the first and are NOT actual failures.
+  - Defensive `UPDATE` backfill: sets `provider='LOCAL'` on any row where the column ended up empty (defensive against exotic SQLite versions where `ADD COLUMN` defaults don't backfill).
+  - `ALTER TABLE "AppSettings" DROP COLUMN "ollamaApiKey"` — wrapped in try/catch so subsequent boots are no-ops. Decision #15: Ollama doesn't authenticate, this field was a local-fork artifact.
+
+- **`backend/src/settings/provider.types.ts`** — new file. Exports `Provider` union, `PROVIDERS` const array, `isProvider()` runtime type guard, `DEFAULT_PROVIDER` constant. Used by both the DTO validator (`@IsIn(PROVIDERS)`) and the service layer (`isProvider()` defends against non-HTTP call paths).
+
+- **`SettingsService` provider routing** (`backend/src/settings/settings.service.ts`):
+  - `getSettings()` returns the new fields with `cloudApiKey` decrypted (consistent with the existing pattern for `usptoApiKey`). The frontend handles display masking. A defensive `isProvider()` guard normalizes any garbage DB value back to `DEFAULT_PROVIDER`.
+  - `updateSettings()` accepts `provider`, `cloudApiKey`, `cloudDefaultModel`, `localDefaultModel`. `provider` is validated both by the DTO `@IsIn` decorator (HTTP boundary) AND by the runtime `isProvider()` guard (defense in depth for direct service-to-service calls). `cloudApiKey` is encrypted before persistence.
+  - Deprecated `ollamaApiKey` field on the DTO is logged-and-ignored for one-cycle back-compat with older clients. The persistence layer no longer sees it (the column was dropped in the migration).
+
+- **17 new backend Jest tests** across `backend/src/settings/settings.service.spec.ts` (11) and `backend/src/prisma/prisma.service.spec.ts` (6, plus 1 regression). Coverage: provider dispatch in get/update, cloudApiKey encryption round-trip, defensive isProvider guard, deprecated ollamaApiKey silent-ignore + warning, usptoApiKey regression, ALTER TABLE issuance and ordering, CHECK constraint enforcement, idempotent re-run handling for duplicate-column and no-such-column errors, gemma4:26b → gemma4:e4b migration regression. Total backend test count: **303** (was 286).
+
+### Changed
+
+- **`UpdateSettingsDto`** (`backend/src/settings/dto/update-settings.dto.ts`) — new optional fields `provider` / `cloudApiKey` / `cloudDefaultModel` / `localDefaultModel`. `ollamaApiKey` retained with `@deprecated` tag for one-cycle back-compat; service logs a warning when received and silently ignores it.
+
+### Removed
+
+- **`AppSettings.ollamaApiKey` column** — Ollama doesn't authenticate; the field was a vestigial PatentForgeLocal-fork artifact. Existing installs have it dropped via the idempotent migration step.
+
+### Migration notes (Run 4)
+
+- Fully backward-compatible for existing PatentForgeLocal installs. The migration is additive: existing rows get `provider='LOCAL'` automatically, preserving the user's prior choice (they installed PatentForgeLocal precisely because they wanted local). The `ollamaApiKey` drop is safe — the field was never actually used (Ollama is unauthenticated by default).
+- Fresh installs land directly in the new schema via the inline `SCHEMA_SQL` constant in `prisma.service.ts`.
+- No version bump in this run — entries accumulate under `[Unreleased]` until Run 8 (cutover + v0.5.0).
+
+### Verification (Run 4)
+
+- backend Jest: **303/303** in 22.9s (+17 from Run 2's 286)
+- frontend Vitest: **201/201** in 11.1s (no frontend changes — pure regression check)
+- claim-drafter pytest: **89/89** in 7.4s (regression)
+- application-generator pytest: **92/92** in 6.1s (regression)
+- compliance-checker pytest: **71/71** in 5.5s (regression)
+- feasibility npm test: **29/29** in 24.1s (regression)
+- `docker compose config --quiet`: exit 0
+- `docker compose build`: all 5 service images built successfully
+
+Total: **785 automated tests green** across 4 services + 2 web tiers.
+
+---
+
+### Added (merge plan Run 2 — LiteLLM provider abstraction)
 
 - **LLM provider abstraction** — all four services (three Python + Node `feasibility`) now route LLM calls through an `LLMClient` boundary that dispatches on a new `provider` setting:
   - **LOCAL** → Ollama via OpenAI-compatible API (existing behavior; backward-compatible default for every existing install).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,8 @@ Full design and implementation plan: `docs/superpowers/specs/2026-04-12-patentfo
 - Versioning: independent from PatentForge, starts at v0.1.0
 - **LLM provider abstraction** (added in PatentForge merge plan Run 2): all four services (3 Python + Node `feasibility`) route LLM calls through an `LLMClient` boundary. Python services use LiteLLM (`litellm` package) for both Ollama (LOCAL) and Anthropic (CLOUD) dispatch. The Node `feasibility` service has the same dispatch shape — LOCAL delegates to `ollama-client.streamMessage`; CLOUD throws `LLMClientCloudNotImplementedError` until Run 4 wires it (Anthropic streaming + tool-call normalization is its own scope). Settings field: `provider: "LOCAL" | "CLOUD"`, `api_key`, `base_url` (LOCAL) — all default to LOCAL for backward compatibility with existing installs.
 
+- **Provider routing in the backend `AppSettings` schema** (Run 4): four new columns persist the LLM provider choice — `provider` (String + SQLite CHECK constraint enforcing LOCAL/CLOUD; SQLite has no native enum, so the safety lives across TS union + DTO `@IsIn` validator + DB CHECK), `cloudApiKey` (encrypted at rest via `encryption.ts`, same pattern as `usptoApiKey`), `cloudDefaultModel` (default `claude-haiku-4-5-20251001`), `localDefaultModel` (default `gemma4:e4b`). The vestigial `ollamaApiKey` column is dropped — Ollama doesn't authenticate. Existing installs migrate idempotently in `prisma.service.ts:migrateSettings()` via `ALTER TABLE ADD COLUMN` with `provider='LOCAL'` backfill. `Provider` type union + `isProvider()` guard + `DEFAULT_PROVIDER` constant live in `backend/src/settings/provider.types.ts`.
+
 ## Upstream
 
 Forked from https://github.com/scottconverse/patentforge

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -222,16 +222,30 @@ model OdpApiUsage {
 
 model AppSettings {
   id                     String  @id @default("singleton")
-  ollamaApiKey           String  @default("")
+
+  // Provider routing (added in PatentForge merge plan Run 4).
+  //
+  // `provider` is a String column with a SQLite CHECK constraint enforcing
+  // {LOCAL, CLOUD} (see SCHEMA_SQL in src/prisma/prisma.service.ts).
+  // The TypeScript type union `Provider` (src/settings/provider.types.ts)
+  // gives compile-time typo safety. SQLite doesn't support native enums,
+  // so the safety lives across three layers: TS union (compile), CHECK
+  // constraint (runtime DB), and DTO validator (HTTP boundary).
+  provider               String  @default("LOCAL")
+  cloudApiKey            String  @default("")          // Anthropic key, encrypted at rest
+  cloudDefaultModel      String  @default("claude-haiku-4-5-20251001")
+  localDefaultModel      String  @default("gemma4:e4b")
+
+  // Existing fields (untouched except ollamaApiKey removed in Run 4).
   ollamaModel            String  @default("gemma4:e4b")
   ollamaUrl              String  @default("http://localhost:11434")
   modelReady             Boolean @default(false)
-  defaultModel           String  @default("gemma4:e4b")
+  defaultModel           String  @default("gemma4:e4b")  // Legacy/compat; per-provider defaults live in {local,cloud}DefaultModel
   researchModel          String  @default("")
   maxTokens              Int     @default(32000)
   interStageDelaySeconds Int     @default(5)
   exportPath             String  @default("")
   autoExport             Boolean @default(true)
-  usptoApiKey            String  @default("")
+  usptoApiKey            String  @default("")           // Encrypted at rest
   encryptionSalt         String  @default("")
 }

--- a/backend/src/prisma/prisma.service.spec.ts
+++ b/backend/src/prisma/prisma.service.spec.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for PrismaService.migrateSettings — Run 4 provider routing migration.
+ *
+ * Verifies the additive ALTER TABLE statements are issued in the right order
+ * and that errors are handled idempotently (duplicate column, no such column).
+ *
+ * Mocks `$executeRawUnsafe` on a stub PrismaService instance — this exercises
+ * the migration logic without needing a real SQLite database. Real-DB schema
+ * verification is covered by cleanroom `docker compose build` (fresh install
+ * via SCHEMA_SQL) and by the existing gemma4:26b→gemma4:e4b migration which
+ * is structurally identical.
+ */
+
+import { PrismaService } from './prisma.service';
+
+type RawCallArg = string;
+
+/**
+ * Build a stub PrismaService that records executeRawUnsafe calls and
+ * exposes the private migrateSettings method for test invocation.
+ */
+function buildStubService(overrides?: {
+  executeRawUnsafe?: jest.Mock;
+}): { service: PrismaService; calls: RawCallArg[] } {
+  const calls: RawCallArg[] = [];
+  const mock = overrides?.executeRawUnsafe
+    ?? jest.fn((sql: string) => {
+      calls.push(sql);
+      return Promise.resolve(0);
+    });
+
+  // Use Object.create on the prototype so the stub has migrateSettings and the
+  // other PrismaService methods, but skips PrismaClient's connection-eager
+  // constructor. We override $executeRawUnsafe to capture the SQL calls.
+  const service = Object.create(PrismaService.prototype) as PrismaService;
+  (service as unknown as { $executeRawUnsafe: jest.Mock }).$executeRawUnsafe = mock;
+
+  return { service, calls };
+}
+
+// migrateSettings is private; access via bracket notation.
+async function runMigrate(service: PrismaService): Promise<void> {
+  return (service as unknown as { migrateSettings: () => Promise<void> }).migrateSettings();
+}
+
+describe('PrismaService.migrateSettings — Run 4 provider routing', () => {
+  it('issues ALTER TABLE for each new provider column in the right order', async () => {
+    const { service, calls } = buildStubService();
+
+    await runMigrate(service);
+
+    // Extract just the ADD COLUMN statements
+    const addColumns = calls.filter((sql) => sql.includes('ADD COLUMN'));
+    const columnNames = addColumns.map((sql) => sql.match(/ADD COLUMN "(\w+)"/)?.[1]);
+
+    expect(columnNames).toContain('provider');
+    expect(columnNames).toContain('cloudApiKey');
+    expect(columnNames).toContain('cloudDefaultModel');
+    expect(columnNames).toContain('localDefaultModel');
+  });
+
+  it('issues DROP COLUMN ollamaApiKey', async () => {
+    const { service, calls } = buildStubService();
+
+    await runMigrate(service);
+
+    const dropCalls = calls.filter((sql) => sql.includes('DROP COLUMN'));
+    expect(dropCalls.some((sql) => sql.includes('"ollamaApiKey"'))).toBe(true);
+  });
+
+  it('issues the defensive UPDATE backfill for provider', async () => {
+    const { service, calls } = buildStubService();
+
+    await runMigrate(service);
+
+    const updateBackfill = calls.find(
+      (sql) => sql.includes('UPDATE "AppSettings"') && sql.includes("'LOCAL'") && sql.includes('IS NULL'),
+    );
+    expect(updateBackfill).toBeDefined();
+  });
+
+  it('issues the provider column WITH a CHECK constraint', async () => {
+    const { service, calls } = buildStubService();
+
+    await runMigrate(service);
+
+    const providerAddCol = calls.find(
+      (sql) => sql.includes('ADD COLUMN "provider"'),
+    );
+    expect(providerAddCol).toBeDefined();
+    expect(providerAddCol).toContain('CHECK');
+    expect(providerAddCol).toContain("'LOCAL'");
+    expect(providerAddCol).toContain("'CLOUD'");
+  });
+
+  it('continues past duplicate-column errors (idempotent ALTER TABLE)', async () => {
+    // First two ADD COLUMN calls succeed, third throws "duplicate column", rest succeed.
+    let callCount = 0;
+    const mock = jest.fn((sql: string) => {
+      callCount += 1;
+      if (callCount === 3 && sql.includes('ADD COLUMN')) {
+        return Promise.reject(new Error('SQLITE_ERROR: duplicate column name: cloudDefaultModel'));
+      }
+      return Promise.resolve(0);
+    });
+
+    const { service } = buildStubService({ executeRawUnsafe: mock });
+
+    // Should not throw
+    await expect(runMigrate(service)).resolves.toBeUndefined();
+
+    // All steps still ran (including ones after the failing one)
+    expect(mock.mock.calls.length).toBeGreaterThan(3);
+  });
+
+  it('continues past "no such column" on DROP COLUMN (re-run case)', async () => {
+    // All ADD COLUMNs and UPDATE succeed; DROP COLUMN throws because column is already gone.
+    const mock = jest.fn((sql: string) => {
+      if (sql.includes('DROP COLUMN')) {
+        return Promise.reject(new Error('SQLITE_ERROR: no such column: ollamaApiKey'));
+      }
+      return Promise.resolve(0);
+    });
+
+    const { service } = buildStubService({ executeRawUnsafe: mock });
+
+    await expect(runMigrate(service)).resolves.toBeUndefined();
+  });
+
+  it('runs the pre-existing gemma4:26b → gemma4:e4b UPDATE (regression)', async () => {
+    const { service, calls } = buildStubService();
+
+    await runMigrate(service);
+
+    // The original migration that PrismaService.migrateSettings was added for
+    const gemmaUpdate = calls.find(
+      (sql) =>
+        sql.includes('UPDATE "AppSettings"') &&
+        sql.includes('gemma4:e4b') &&
+        sql.includes('gemma4:26b'),
+    );
+    expect(gemmaUpdate).toBeDefined();
+  });
+});

--- a/backend/src/prisma/prisma.service.ts
+++ b/backend/src/prisma/prisma.service.ts
@@ -72,6 +72,58 @@ export class PrismaService extends PrismaClient implements OnModuleInit, OnModul
       const msg = err instanceof Error ? err.message : String(err);
       console.warn(`[Prisma] Settings migration warning: ${msg}`);
     }
+
+    // PatentForge merge plan Run 4: provider routing.
+    // Each ALTER TABLE is wrapped individually — "duplicate column" errors are
+    // expected on every boot after the first and are NOT actual failures.
+    const addColumnSteps: Array<[string, string]> = [
+      ['provider', `ADD COLUMN "provider" TEXT NOT NULL DEFAULT 'LOCAL' CHECK ("provider" IN ('LOCAL', 'CLOUD'))`],
+      ['cloudApiKey', `ADD COLUMN "cloudApiKey" TEXT NOT NULL DEFAULT ''`],
+      ['cloudDefaultModel', `ADD COLUMN "cloudDefaultModel" TEXT NOT NULL DEFAULT 'claude-haiku-4-5-20251001'`],
+      ['localDefaultModel', `ADD COLUMN "localDefaultModel" TEXT NOT NULL DEFAULT 'gemma4:e4b'`],
+    ];
+
+    for (const [col, sql] of addColumnSteps) {
+      try {
+        await this.$executeRawUnsafe(`ALTER TABLE "AppSettings" ${sql}`);
+        console.log(`[Prisma] migrate: added AppSettings.${col}`);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        // Idempotent: duplicate-column errors are expected on every boot after the first.
+        if (!msg.toLowerCase().includes('duplicate column')) {
+          console.warn(`[Prisma] migrate: could not add AppSettings.${col} — ${msg}`);
+        }
+      }
+    }
+
+    // Defensive backfill — set provider='LOCAL' on any pre-Run-4 row that
+    // somehow ended up with an empty value (e.g. ADD COLUMN ran but the
+    // default didn't backfill on an exotic SQLite version).
+    try {
+      await this.$executeRawUnsafe(
+        `UPDATE "AppSettings"
+         SET "provider" = 'LOCAL'
+         WHERE "id" = 'singleton' AND ("provider" IS NULL OR "provider" = '')`,
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`[Prisma] migrate: provider backfill warning: ${msg}`);
+    }
+
+    // Drop the vestigial ollamaApiKey column. Ollama doesn't authenticate;
+    // this field was a local-fork artifact. SQLite ≥3.35 supports DROP COLUMN.
+    // Wrapped in try/catch so it's a no-op on installs where the column
+    // was already dropped or never existed.
+    try {
+      await this.$executeRawUnsafe(`ALTER TABLE "AppSettings" DROP COLUMN "ollamaApiKey"`);
+      console.log('[Prisma] migrate: dropped AppSettings.ollamaApiKey');
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      // "no such column" is expected once the migration has already run.
+      if (!msg.toLowerCase().includes('no such column')) {
+        console.warn(`[Prisma] migrate: could not drop AppSettings.ollamaApiKey — ${msg}`);
+      }
+    }
   }
 }
 

--- a/backend/src/prisma/prisma.service.ts
+++ b/backend/src/prisma/prisma.service.ts
@@ -266,7 +266,10 @@ CREATE TABLE "OdpApiUsage" (
 );
 CREATE TABLE "AppSettings" (
     "id" TEXT NOT NULL PRIMARY KEY DEFAULT 'singleton',
-    "ollamaApiKey" TEXT NOT NULL DEFAULT '',
+    "provider" TEXT NOT NULL DEFAULT 'LOCAL' CHECK ("provider" IN ('LOCAL', 'CLOUD')),
+    "cloudApiKey" TEXT NOT NULL DEFAULT '',
+    "cloudDefaultModel" TEXT NOT NULL DEFAULT 'claude-haiku-4-5-20251001',
+    "localDefaultModel" TEXT NOT NULL DEFAULT 'gemma4:e4b',
     "ollamaModel" TEXT NOT NULL DEFAULT 'gemma4:e4b',
     "ollamaUrl" TEXT NOT NULL DEFAULT 'http://localhost:11434',
     "modelReady" BOOLEAN NOT NULL DEFAULT false,

--- a/backend/src/settings/dto/update-settings.dto.ts
+++ b/backend/src/settings/dto/update-settings.dto.ts
@@ -1,7 +1,34 @@
-import { IsOptional, IsString, IsInt, IsNumber, IsBoolean, Min } from 'class-validator';
+import { IsOptional, IsString, IsInt, IsNumber, IsBoolean, IsIn, Min } from 'class-validator';
 import { Type } from 'class-transformer';
+import { PROVIDERS } from '../provider.types';
 
 export class UpdateSettingsDto {
+  // ── Provider routing (Run 4) ──────────────────────────────────────────────
+
+  @IsOptional()
+  @IsString()
+  @IsIn(PROVIDERS)
+  provider?: 'LOCAL' | 'CLOUD';
+
+  @IsOptional()
+  @IsString()
+  cloudApiKey?: string;
+
+  @IsOptional()
+  @IsString()
+  cloudDefaultModel?: string;
+
+  @IsOptional()
+  @IsString()
+  localDefaultModel?: string;
+
+  // ── Legacy / general ──────────────────────────────────────────────────────
+
+  /**
+   * @deprecated Removed in Run 4 — Ollama doesn't authenticate. Field accepted
+   * for one-cycle backward compatibility with older clients; the value is
+   * ignored by the service and a deprecation warning is logged.
+   */
   @IsOptional()
   @IsString()
   ollamaApiKey?: string;

--- a/backend/src/settings/provider.types.ts
+++ b/backend/src/settings/provider.types.ts
@@ -1,0 +1,27 @@
+/**
+ * LLM provider routing — TypeScript-level safety for AppSettings.provider.
+ *
+ * Prisma can't emit an enum on SQLite (Prisma P1012), so the type-safety
+ * lives across three layers:
+ *
+ *   1. **Compile-time** — this `Provider` union catches typos in TS code.
+ *   2. **HTTP boundary** — the DTO validator (`update-settings.dto.ts`)
+ *      rejects requests with unrecognized values.
+ *   3. **Runtime DB** — the SQLite CHECK constraint in the AppSettings table
+ *      (see `SCHEMA_SQL` in `src/prisma/prisma.service.ts`) rejects writes
+ *      with bad values even if a path skipped the DTO.
+ *
+ * Introduced in PatentForge merge plan Run 4.
+ */
+
+export type Provider = 'LOCAL' | 'CLOUD';
+
+export const PROVIDERS: readonly Provider[] = ['LOCAL', 'CLOUD'] as const;
+
+/** Type guard: narrow `unknown` (e.g. an inbound JSON value) to a valid Provider. */
+export function isProvider(value: unknown): value is Provider {
+  return typeof value === 'string' && (PROVIDERS as readonly string[]).includes(value);
+}
+
+/** Default provider for fresh installs and for migrations of pre-Run-4 rows. */
+export const DEFAULT_PROVIDER: Provider = 'LOCAL';

--- a/backend/src/settings/settings.service.spec.ts
+++ b/backend/src/settings/settings.service.spec.ts
@@ -1,0 +1,232 @@
+/**
+ * Tests for SettingsService — Run 4 provider routing + encryption coverage.
+ *
+ * Mocks PrismaService at the appSettings.upsert/update boundary so the
+ * service logic is exercised without needing a real SQLite database.
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { SettingsService } from './settings.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { encrypt, decrypt } from './encryption';
+import { DEFAULT_PROVIDER } from './provider.types';
+
+// Fixed test salt — deterministic encryption round-trips across tests.
+const TEST_SALT = 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
+
+function buildAppSettingsRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'singleton',
+    provider: 'LOCAL',
+    cloudApiKey: '',
+    cloudDefaultModel: 'claude-haiku-4-5-20251001',
+    localDefaultModel: 'gemma4:e4b',
+    ollamaModel: 'gemma4:e4b',
+    ollamaUrl: 'http://localhost:11434',
+    modelReady: false,
+    defaultModel: 'gemma4:e4b',
+    researchModel: '',
+    maxTokens: 32000,
+    interStageDelaySeconds: 5,
+    exportPath: '',
+    autoExport: true,
+    usptoApiKey: '',
+    encryptionSalt: TEST_SALT,
+    ...overrides,
+  };
+}
+
+describe('SettingsService — Run 4 provider routing', () => {
+  let service: SettingsService;
+  let prismaMock: {
+    appSettings: {
+      upsert: jest.Mock;
+      update: jest.Mock;
+    };
+    odpApiUsage: { findMany: jest.Mock };
+  };
+
+  beforeEach(async () => {
+    prismaMock = {
+      appSettings: {
+        upsert: jest.fn(),
+        update: jest.fn(),
+      },
+      odpApiUsage: { findMany: jest.fn().mockResolvedValue([]) },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SettingsService,
+        { provide: PrismaService, useValue: prismaMock },
+      ],
+    }).compile();
+
+    service = module.get<SettingsService>(SettingsService);
+
+    // Stub the salt so encryption works without invoking onModuleInit's DB calls.
+    (service as unknown as { salt: string }).salt = TEST_SALT;
+  });
+
+  // ── getSettings ───────────────────────────────────────────────────────────
+
+  describe('getSettings', () => {
+    it('returns provider=LOCAL and decrypted empty api keys on fresh install', async () => {
+      prismaMock.appSettings.upsert.mockResolvedValue(buildAppSettingsRow());
+
+      const result = await service.getSettings();
+
+      expect(result.provider).toBe('LOCAL');
+      expect(result.cloudApiKey).toBe('');
+      expect(result.cloudDefaultModel).toBe('claude-haiku-4-5-20251001');
+      expect(result.localDefaultModel).toBe('gemma4:e4b');
+      expect(result.encryptionHealthy).toBe(true);
+    });
+
+    it('decrypts cloudApiKey from ciphertext at rest', async () => {
+      const plaintext = 'sk-ant-test-key-abc123';
+      const ciphertext = encrypt(plaintext, TEST_SALT);
+      prismaMock.appSettings.upsert.mockResolvedValue(
+        buildAppSettingsRow({ provider: 'CLOUD', cloudApiKey: ciphertext }),
+      );
+
+      const result = await service.getSettings();
+
+      expect(result.provider).toBe('CLOUD');
+      expect(result.cloudApiKey).toBe(plaintext);
+    });
+
+    it('defends against garbage provider values from a hand-edited DB row', async () => {
+      prismaMock.appSettings.upsert.mockResolvedValue(
+        buildAppSettingsRow({ provider: 'XYZ_BOGUS' }),
+      );
+
+      const result = await service.getSettings();
+
+      expect(result.provider).toBe(DEFAULT_PROVIDER);
+      expect(result.provider).toBe('LOCAL');
+    });
+  });
+
+  // ── updateSettings ────────────────────────────────────────────────────────
+
+  describe('updateSettings', () => {
+    it('encrypts cloudApiKey before persistence', async () => {
+      const plaintext = 'sk-ant-secret-xyz789';
+
+      // Capture the data passed to upsert
+      let capturedData: Record<string, unknown> | undefined;
+      prismaMock.appSettings.upsert.mockImplementation((args: any) => {
+        capturedData = args.update;
+        const stored = capturedData?.cloudApiKey as string;
+        return Promise.resolve(
+          buildAppSettingsRow({ provider: 'CLOUD', cloudApiKey: stored ?? '' }),
+        );
+      });
+
+      await service.updateSettings({ provider: 'CLOUD', cloudApiKey: plaintext });
+
+      expect(capturedData).toBeDefined();
+      // Ciphertext is NOT the plaintext value
+      expect(capturedData!.cloudApiKey).not.toBe(plaintext);
+      // Ciphertext round-trips via decrypt
+      expect(decrypt(capturedData!.cloudApiKey as string, TEST_SALT)).toBe(plaintext);
+    });
+
+    it('returns the decrypted cloudApiKey in the response after writing', async () => {
+      const plaintext = 'sk-ant-roundtrip-test';
+
+      prismaMock.appSettings.upsert.mockImplementation((args: any) => {
+        const stored = args.update.cloudApiKey;
+        return Promise.resolve(
+          buildAppSettingsRow({ provider: 'CLOUD', cloudApiKey: stored }),
+        );
+      });
+
+      const result = await service.updateSettings({
+        provider: 'CLOUD',
+        cloudApiKey: plaintext,
+      });
+
+      expect(result.cloudApiKey).toBe(plaintext);
+      expect(result.provider).toBe('CLOUD');
+    });
+
+    it('persists provider value', async () => {
+      let capturedData: Record<string, unknown> | undefined;
+      prismaMock.appSettings.upsert.mockImplementation((args: any) => {
+        capturedData = args.update;
+        return Promise.resolve(buildAppSettingsRow({ provider: 'CLOUD' }));
+      });
+
+      await service.updateSettings({ provider: 'CLOUD' });
+
+      expect(capturedData!.provider).toBe('CLOUD');
+    });
+
+    it('persists cloudDefaultModel and localDefaultModel independently', async () => {
+      let capturedData: Record<string, unknown> | undefined;
+      prismaMock.appSettings.upsert.mockImplementation((args: any) => {
+        capturedData = args.update;
+        return Promise.resolve(buildAppSettingsRow({
+          cloudDefaultModel: 'claude-opus-4-5-test',
+          localDefaultModel: 'gemma4:custom',
+        }));
+      });
+
+      await service.updateSettings({
+        cloudDefaultModel: 'claude-opus-4-5-test',
+        localDefaultModel: 'gemma4:custom',
+      });
+
+      expect(capturedData!.cloudDefaultModel).toBe('claude-opus-4-5-test');
+      expect(capturedData!.localDefaultModel).toBe('gemma4:custom');
+    });
+
+    it('rejects unknown provider via runtime isProvider() guard', async () => {
+      // The DTO @IsIn validator would normally reject this at the HTTP boundary,
+      // but a non-HTTP call path (e.g. another service calling updateSettings
+      // directly) bypasses that. The runtime guard catches it.
+      await expect(
+        service.updateSettings({ provider: 'GARBAGE' as unknown as 'LOCAL' | 'CLOUD' }),
+      ).rejects.toThrow(/Invalid provider/);
+    });
+
+    it('silently ignores deprecated ollamaApiKey field (back-compat for one cycle)', async () => {
+      let capturedData: Record<string, unknown> | undefined;
+      prismaMock.appSettings.upsert.mockImplementation((args: any) => {
+        capturedData = args.update;
+        return Promise.resolve(buildAppSettingsRow());
+      });
+
+      const warnSpy = jest.spyOn(service['logger'], 'warn').mockImplementation();
+
+      await service.updateSettings({ ollamaApiKey: 'should-be-ignored' });
+
+      // Persistence layer never sees ollamaApiKey (it was dropped in Run 4 migration)
+      expect(capturedData).not.toHaveProperty('ollamaApiKey');
+      // Deprecation warning was logged
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/deprecated `ollamaApiKey`/),
+      );
+
+      warnSpy.mockRestore();
+    });
+
+    it('persists usptoApiKey encrypted (existing behavior preserved)', async () => {
+      const plaintext = 'uspto-key-test-456';
+      let capturedData: Record<string, unknown> | undefined;
+      prismaMock.appSettings.upsert.mockImplementation((args: any) => {
+        capturedData = args.update;
+        return Promise.resolve(
+          buildAppSettingsRow({ usptoApiKey: capturedData?.usptoApiKey as string }),
+        );
+      });
+
+      await service.updateSettings({ usptoApiKey: plaintext });
+
+      expect(capturedData!.usptoApiKey).not.toBe(plaintext);
+      expect(decrypt(capturedData!.usptoApiKey as string, TEST_SALT)).toBe(plaintext);
+    });
+  });
+});

--- a/backend/src/settings/settings.service.ts
+++ b/backend/src/settings/settings.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { UpdateSettingsDto } from './dto/update-settings.dto';
 import { encrypt, decrypt, generateSalt, DecryptionError } from './encryption';
+import { DEFAULT_PROVIDER, isProvider, type Provider } from './provider.types';
 
 const SINGLETON_ID = 'singleton';
 
@@ -66,6 +67,10 @@ export class SettingsService implements OnModuleInit {
 
   /**
    * Get settings with API keys decrypted for use.
+   *
+   * Returns plaintext API keys (cloudApiKey, usptoApiKey) — same pattern used
+   * pre-Run-4 for usptoApiKey. The frontend Settings page renders them masked
+   * for display; the unmasked value flows back on save to support edit-in-place.
    */
   async getSettings() {
     const raw = await this.prisma.appSettings.upsert({
@@ -74,10 +79,10 @@ export class SettingsService implements OnModuleInit {
       update: {},
     });
 
-    let ollamaApiKey = '';
+    let cloudApiKey = '';
     let usptoApiKey = '';
     try {
-      ollamaApiKey = decrypt(raw.ollamaApiKey, this.salt);
+      cloudApiKey = decrypt(raw.cloudApiKey, this.salt);
       usptoApiKey = decrypt(raw.usptoApiKey, this.salt);
     } catch (err) {
       if (err instanceof DecryptionError) {
@@ -88,9 +93,15 @@ export class SettingsService implements OnModuleInit {
       }
     }
 
+    // Defensive: provider in DB should already be 'LOCAL' or 'CLOUD' thanks to
+    // the CHECK constraint and the migration backfill, but if a hand-edited
+    // row sneaks through, fall back to the default rather than expose garbage.
+    const provider: Provider = isProvider(raw.provider) ? raw.provider : DEFAULT_PROVIDER;
+
     return {
       ...raw,
-      ollamaApiKey,
+      provider,
+      cloudApiKey,
       usptoApiKey,
       encryptionHealthy: this.encryptionHealthy,
     };
@@ -101,7 +112,31 @@ export class SettingsService implements OnModuleInit {
    */
   async updateSettings(dto: UpdateSettingsDto) {
     const data: Record<string, unknown> = {};
-    if (dto.ollamaApiKey !== undefined) data.ollamaApiKey = encrypt(dto.ollamaApiKey, this.salt);
+
+    // ── Provider routing fields ────────────────────────────────────────────
+    if (dto.provider !== undefined) {
+      // The DTO validator (@IsIn(PROVIDERS)) already rejected bad values,
+      // but defense-in-depth — the runtime type guard catches a path that
+      // somehow skipped class-validator (e.g. a direct service call).
+      if (!isProvider(dto.provider)) {
+        throw new Error(`Invalid provider: ${String(dto.provider)}`);
+      }
+      data.provider = dto.provider;
+    }
+    if (dto.cloudApiKey !== undefined) data.cloudApiKey = encrypt(dto.cloudApiKey, this.salt);
+    if (dto.cloudDefaultModel !== undefined) data.cloudDefaultModel = dto.cloudDefaultModel;
+    if (dto.localDefaultModel !== undefined) data.localDefaultModel = dto.localDefaultModel;
+
+    // ── Legacy / general fields ────────────────────────────────────────────
+    if (dto.ollamaApiKey !== undefined) {
+      // Deprecated in Run 4 — Ollama doesn't authenticate; the column was
+      // dropped from AppSettings. Older clients may still send this; log
+      // and ignore. Removing the field entirely from the DTO would break
+      // those clients with a 400 instead of letting them through.
+      this.logger.warn(
+        'updateSettings received deprecated `ollamaApiKey` field — Ollama does not authenticate; value ignored. Update your client to drop this field.',
+      );
+    }
     if (dto.defaultModel !== undefined) data.defaultModel = dto.defaultModel;
     if (dto.researchModel !== undefined) data.researchModel = dto.researchModel;
     if (dto.maxTokens !== undefined) data.maxTokens = dto.maxTokens;
@@ -122,10 +157,10 @@ export class SettingsService implements OnModuleInit {
     // After a successful update, encryption should be healthy (new keys just encrypted)
     this.encryptionHealthy = true;
 
-    let ollamaApiKey = '';
+    let cloudApiKey = '';
     let usptoApiKey = '';
     try {
-      ollamaApiKey = decrypt(raw.ollamaApiKey, this.salt);
+      cloudApiKey = decrypt(raw.cloudApiKey, this.salt);
       usptoApiKey = decrypt(raw.usptoApiKey, this.salt);
     } catch (err) {
       if (err instanceof DecryptionError) {
@@ -135,9 +170,12 @@ export class SettingsService implements OnModuleInit {
       }
     }
 
+    const provider: Provider = isProvider(raw.provider) ? raw.provider : DEFAULT_PROVIDER;
+
     return {
       ...raw,
-      ollamaApiKey,
+      provider,
+      cloudApiKey,
       usptoApiKey,
       encryptionHealthy: this.encryptionHealthy,
     };


### PR DESCRIPTION
## Run 4 of the 8-step PatentForge merge plan

Adds the Prisma schema fields that surface the LLM provider choice to the backend, expands the inline schema-init SQL + idempotent runtime migration, and reshapes `SettingsService` + DTO to accept/return the new fields with `cloudApiKey` encrypted at rest. Backend data-layer companion to Run 2's `LLMClient` abstraction ([PR #12](https://github.com/scottconverse/patentforgelocal/pull/12)).

Builds on Run 2's branch. After Run 4 merges, Run 5 can build the frontend Settings provider section against a real backend.

## What changed

- **`backend/prisma/schema.prisma`** — `AppSettings` adds `provider` (String + SQLite `CHECK ('LOCAL', 'CLOUD')` — SQLite has no Prisma enum support per P1012, so safety lives across TS union + DTO `@IsIn` + DB CHECK), `cloudApiKey` (encrypted at rest), `cloudDefaultModel` (default `claude-haiku-4-5-20251001`), `localDefaultModel` (default `gemma4:e4b`). Drops vestigial `ollamaApiKey` column.
- **`backend/src/prisma/prisma.service.ts`** — `SCHEMA_SQL` constant updated to match (fresh installs). `migrateSettings()` expanded with idempotent `ALTER TABLE ADD COLUMN` for each new column + defensive `provider='LOCAL'` backfill + `DROP COLUMN ollamaApiKey`. Each step wrapped in try/catch so `duplicate column` / `no such column` errors on re-run are no-ops.
- **`backend/src/settings/provider.types.ts`** *(new)* — `Provider` type union, `PROVIDERS` const, `isProvider()` runtime guard, `DEFAULT_PROVIDER`.
- **`backend/src/settings/settings.service.ts`** — `getSettings()` decrypts `cloudApiKey` (same pattern as `usptoApiKey`), defensive `isProvider()` normalizes garbage DB values to `DEFAULT_PROVIDER`. `updateSettings()` encrypts `cloudApiKey`, validates provider at both DTO and runtime layers. Deprecated `ollamaApiKey` silently ignored with warning.
- **`backend/src/settings/dto/update-settings.dto.ts`** — adds `provider` (`@IsIn(PROVIDERS)`), `cloudApiKey`, `cloudDefaultModel`, `localDefaultModel`. `ollamaApiKey` retained as `@deprecated`.
- **`CLAUDE.md` + `CHANGELOG.md`** — new bullet + `[Unreleased]` Run 4 entry.

## Verification (all green)

| Suite | Result | Time |
|---|---|---|
| backend Jest | **303/303** (+17) | 22.9s |
| frontend Vitest | **201/201** (regression) | 11.1s |
| claim-drafter pytest | **89/89** | 7.4s |
| application-generator pytest | **92/92** | 6.1s |
| compliance-checker pytest | **71/71** | 5.5s |
| feasibility npm test | **29/29** | 24.1s |
| `docker compose config --quiet` | exit 0 | — |
| `docker compose build` (5 images) | success | — |
| **Total** | **785 tests** | — |

17 new tests across `settings.service.spec.ts` (11) and `prisma.service.spec.ts` (6 + 1 regression). Coverage: provider dispatch, `cloudApiKey` encryption round-trip, defensive guard against garbage DB values, deprecated `ollamaApiKey` silent-ignore + warning, `usptoApiKey` regression, ALTER TABLE issuance and ordering, CHECK constraint enforcement, idempotent re-run handling.

## 8-lens audit

Full report at `.pipeline-cw/2026-05-15-0455-feature-provider-settings/audit.md`.

**0 BLOCKER · 0 MAJOR · 2 MINOR · 1 NIT** (all with valid `out-of-scope-because`):

1. `ARCHITECTURE.md` stale on the new `provider.types.ts` module — out-of-scope-because: Run 7 doc rewrite.
2. `PatentForge-Architecture.docx` stale — same as #1.
3. **NIT**: response-time masking of `cloudApiKey` would be stricter than the existing `usptoApiKey` pattern. Better addressed as a coordinated security pass than introduced piecemeal here.

## Pre-locked decisions honored

From `memory/project_patentforge_merge_decisions.md`:
- **#2** Provider enum *(amended — Prisma doesn't support SQLite enums; equivalent safety via three-layer TS/DTO/CHECK)*
- **#3** Two-field defaults: `cloudDefaultModel` + `localDefaultModel` both persisted
- **#5** Cost-cap UX hidden in local mode (UI concern; backend column unchanged)
- **#8** DB-file rename deferred to Run 8 cutover *(out-of-scope-because: ties to repo-name flip)*
- **#15** Encrypt `cloudApiKey`, drop `ollamaApiKey`
- **#17** Auto-set `provider=LOCAL` silently in upgrade migration

## Backward compatibility

Fully back-compat. Existing rows migrate idempotently to `provider='LOCAL'`. `ollamaApiKey` drop is safe (Ollama doesn't authenticate; field was never used). Older clients that PATCH with `ollamaApiKey` get a deprecation warning, value ignored.

## Run trace

- `scope.md` — `.pipeline-cw/2026-05-15-0455-feature-provider-settings/scope.md`
- `log.md` — `.pipeline-cw/2026-05-15-0455-feature-provider-settings/log.md`
- `audit.md` — `.pipeline-cw/2026-05-15-0455-feature-provider-settings/audit.md`

---
_Generated by pipeline-cw. Run-id: `2026-05-15-0455-feature-provider-settings`._