### PR TITLE
Add GitHub cost hygiene guardrails

### DIFF
--- a/.github/COST_HYGIENE.md
+++ b/.github/COST_HYGIENE.md
@@ -1,0 +1,12 @@
+# Cost Hygiene
+
+This repository uses conservative GitHub resource defaults:
+
+- Keep CI artifacts short-lived unless they are release deliverables.
+- Put final downloadable outputs in Releases, not long-lived Actions artifacts.
+- Use GitHub Packages only for real packages or container images, not as artifact overflow.
+- Prefer `concurrency.cancel-in-progress: true` for push and pull request workflows.
+- Keep expensive jobs manual, path-filtered, or limited to meaningful changes.
+- Keep multi-OS CI public where appropriate; private Windows/macOS jobs are more cost-sensitive.
+- Do not use Codespaces as a CI substitute.
+- Use the manual `Cost Hygiene Check` workflow before cleanup so nothing important is deleted by accident.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
 # Preemptively opt in to Node 24 runner before June 2026 forced migration
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
@@ -177,5 +181,6 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
+          retention-days: 7
           name: playwright-results
           path: frontend/e2e-results/

--- a/.github/workflows/cost-hygiene.yml
+++ b/.github/workflows/cost-hygiene.yml
@@ -1,0 +1,68 @@
+name: Cost Hygiene Check
+
+on:
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Summarize retained artifacts and caches
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          echo "## Cost Hygiene Check" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "This workflow reports retained Actions storage signals. It does not delete anything." >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          artifacts_json="$(gh api "/repos/${GITHUB_REPOSITORY}/actions/artifacts?per_page=100")"
+          caches_json="$(gh api "/repos/${GITHUB_REPOSITORY}/actions/caches?per_page=100")"
+          artifact_count="$(jq '.total_count // 0' <<<"$artifacts_json")"
+          cache_count="$(jq '.total_count // 0' <<<"$caches_json")"
+          artifact_bytes="$(jq '[.artifacts[]?.size_in_bytes // 0] | add // 0' <<<"$artifacts_json")"
+          cache_bytes="$(jq '[.actions_caches[]?.size_in_bytes // 0] | add // 0' <<<"$caches_json")"
+
+          {
+            echo "| Signal | Count | Approx MB |"
+            echo "|---|---:|---:|"
+            awk -v c="$artifact_count" -v b="$artifact_bytes" 'BEGIN { printf "| Actions artifacts | %s | %.1f |\n", c, b / 1048576 }'
+            awk -v c="$cache_count" -v b="$cache_bytes" 'BEGIN { printf "| Actions caches | %s | %.1f |\n", c, b / 1048576 }'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Check workflow guardrails
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Workflow guardrails" >> "$GITHUB_STEP_SUMMARY"
+          missing_concurrency=0
+          missing_retention=0
+          if compgen -G ".github/workflows/*.yml" > /dev/null || compgen -G ".github/workflows/*.yaml" > /dev/null; then
+            for wf in .github/workflows/*.yml .github/workflows/*.yaml; do
+              [ -e "$wf" ] || continue
+              if grep -Eq 'pull_request|push:' "$wf" && ! grep -Eq '^concurrency:' "$wf"; then
+                echo "- Missing top-level concurrency: \`$wf\`" >> "$GITHUB_STEP_SUMMARY"
+                missing_concurrency=1
+              fi
+              if grep -Eq 'actions/upload-artifact@' "$wf" && ! grep -Eq 'retention-days:' "$wf"; then
+                echo "- Artifact upload without explicit retention-days: \`$wf\`" >> "$GITHUB_STEP_SUMMARY"
+                missing_retention=1
+              fi
+            done
+          fi
+          if [ "$missing_concurrency" -eq 0 ] && [ "$missing_retention" -eq 0 ]; then
+            echo "- No obvious missing workflow guardrails found." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,9 @@
 name: Release
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     tags: ['v*']
@@ -83,6 +87,7 @@ jobs:
       - name: Upload Windows installer
         uses: actions/upload-artifact@v4
         with:
+          retention-days: 14
           name: windows-installer
           path: build/PatentForge-*-Setup.exe
 
@@ -170,6 +175,7 @@ jobs:
       - name: Upload Mac installers
         uses: actions/upload-artifact@v4
         with:
+          retention-days: 14
           name: mac-dmg
           path: build/PatentForge-*.dmg
 
@@ -240,6 +246,7 @@ jobs:
       - name: Upload Linux installers
         uses: actions/upload-artifact@v4
         with:
+          retention-days: 14
           name: linux-appimage
           path: build/PatentForge-*.AppImage
 


### PR DESCRIPTION
Adds non-destructive GitHub resource guardrails:

- explicit artifact retention where uploads were missing it
- top-level concurrency cancellation for push/PR workflows where missing
- a manual Cost Hygiene Check workflow that reports artifacts/caches without deleting anything
- a short cost-hygiene policy covering Packages, Releases, Codespaces, and multi-OS CI

This PR intentionally does not delete artifacts, caches, releases, LFS objects, packages, or change repo visibility.