### PR TITLE
ci: add installer-test caller workflow

### DIFF
--- a/.github/workflows/installer-test.yml
+++ b/.github/workflows/installer-test.yml
@@ -1,0 +1,16 @@
+# Calls the central reusable installer-test workflow.
+# Managed by scottconverse/installer-ci; edit there, not here.
+name: installer-test
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+jobs:
+  installer-test:
+    uses: scottconverse/installer-ci/.github/workflows/installer-test.yml@main
+    permissions:
+      contents: read
+      packages: read
+    secrets: inherit


### PR DESCRIPTION
Adds the reusable installer-test caller from scottconverse/installer-ci. On merge (and on this PR) it auto-detects this repo's installer type(s) and runs a full build/install/launch/upgrade/uninstall test. No-ops green if no installer is detected.